### PR TITLE
Change <= to < and ==

### DIFF
--- a/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/loop/LoopCondition.java
+++ b/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/loop/LoopCondition.java
@@ -2,9 +2,11 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.loop;
 
 public class LoopCondition {
 	public boolean evaluateLoop(int i, int n) {
-		if (i <= n) {
+		if (i < n) {
 			return true;
-		} else {
+		} else if (i == n) {
+                        return true;
+                } else {
 			return false;
 		}
 	}


### PR DESCRIPTION
One-liners lead to unclear code that has too much responsibility crammed into too little space. It's better to do less per line and keep the code readable. This changes the very complex and ambiguous operation `<=` into two separate, easily understood operations `<` and `==`.
