### PR TITLE
pom.xml and NewLineStringReturner fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,14 @@
   <build>
     <plugins>
       <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.3</version>
+          <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.3</version>

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/NewLineStringReturner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/NewLineStringReturner.java
@@ -5,7 +5,8 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 public class NewLineStringReturner implements StringStringReturner {
 	
 	public String getReturnString() {
-		StringBuilder myStringBuilder = new StringBuilder("\n");
+		String systemDefaultNewLineString = System.getProperty("line.separator");
+		StringBuilder myStringBuilder = new StringBuilder(systemDefaultNewLineString);
 		String myString = myStringBuilder.toString();
 		return new String(myString);
 	}


### PR DESCRIPTION
Altered pom.xml to use jdk7 to build project and replaced '\n' character with corresponding system property.
