### PR TITLE
Fix magic number in LoopInitializer

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopInitializer.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopInitializer.java
@@ -1,7 +1,10 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.loop;
 
 public class LoopInitializer {
+	
+	public static final int LOOP_INIT_VALUE = 1;
+	
 	public int getLoopInitializationPoint() {
-		return 1;
+		return LoopInitializer.LOOP_INIT_VALUE;
 	}
 }


### PR DESCRIPTION
Use of magic numbers in code is discouraged, this commit fixes
usage of a magic number in LoopInitializer by adding a proper
class constant for that magic number.
