### PR TITLE
Resolve issue #77 "Integer division done wrong"

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/IntegerDivider.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/IntegerDivider.java
@@ -16,7 +16,12 @@ public class IntegerDivider {
 			double dbFirstNumber = (double) nFirstInteger;
 			double dbSecondNumber = (double) nSecondInteger;
 			double dbQuotient = dbFirstNumber / dbSecondNumber;
-			double dbRoundedQuotient = Math.floor(dbQuotient);
+			double dbRoundedQuotient = 0;
+			if(dbQuotient < 0){
+				dbRoundedQuotient = Math.ceil(dbQuotient);
+			else if(dbQuotient > 0){
+				dbRoundedQuotient = Math.floor(dbQuotient);
+			}
 			int nIntegerQuotient = (int) dbRoundedQuotient;
 			return nIntegerQuotient;
 		}


### PR DESCRIPTION
This commit makes the rounding function round towards zero instead of just down.

This resolves issue #77 in the tracker.

A typo was made in the commit message in which "issue #76" was resolved. That should read "issue #77" instead.
