### PR TITLE
Separate output generation from the loop iteration logic.

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/FizzBuzz.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/FizzBuzz.java
@@ -1,22 +1,10 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl;
 
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.BuzzStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.BuzzStringPrinterFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.FizzStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.FizzStringPrinterFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.IntIntegerPrinterFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.factories.IntegerPrinterFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.factories.IsEvenlyDivisibleStrategyFactory;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.LoopComponentFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.NewLineStringPrinterFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.NoFizzNoBuzzStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.factories.StringPrinterFactory;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.loop.LoopCondition;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.loop.LoopInitializer;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.loop.LoopStep;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.printers.IntegerPrinter;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.printers.StringPrinter;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.IsEvenlyDivisibleStrategy;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.SingleStepOutputGenerationStrategy;
 
 public class FizzBuzz {
 	public void fizzbuzz(int nTotalCount) {
@@ -27,35 +15,11 @@ public class FizzBuzz {
 		LoopCondition myLoopCondition = myLoopComponentFactory.createLoopCondition();
 		LoopStep myLoopStep = myLoopComponentFactory.createLoopStep();
 		
-		IsEvenlyDivisibleStrategyFactory myFizzStrategyFactory = new FizzStrategyFactory();
-		IsEvenlyDivisibleStrategy myFizzStrategy = myFizzStrategyFactory.createIsEvenlyDivisibleStrategy();
-		StringPrinterFactory myFizzStringPrinterFactory = new FizzStringPrinterFactory();
-		StringPrinter myFizzStringPrinter = myFizzStringPrinterFactory.createStringPrinter();
-		
-		IsEvenlyDivisibleStrategyFactory myBuzzStrategyFactory = new BuzzStrategyFactory();
-		IsEvenlyDivisibleStrategy myBuzzStrategy = myBuzzStrategyFactory.createIsEvenlyDivisibleStrategy();	
-		StringPrinterFactory myBuzzStringPrinterFactory = new BuzzStringPrinterFactory();
-		StringPrinter myBuzzStringPrinter = myBuzzStringPrinterFactory.createStringPrinter();
-		
-		IsEvenlyDivisibleStrategyFactory myNoFizzNoBuzzStrategyFactory = new NoFizzNoBuzzStrategyFactory();
-		IsEvenlyDivisibleStrategy myNoFizzNoBuzzStrategy = myNoFizzNoBuzzStrategyFactory.createIsEvenlyDivisibleStrategy();
-		IntegerPrinterFactory myIntIntegerPrinterFactory = new IntIntegerPrinterFactory();
-		IntegerPrinter myIntIntegerPrinter = myIntIntegerPrinterFactory.createPrinter();
-		
-		StringPrinterFactory myNewLineStringPrinterFactory = new NewLineStringPrinterFactory();
-		StringPrinter myNewLinePrinter = myNewLineStringPrinterFactory.createStringPrinter();
+		SingleStepOutputGenerationStrategy myGenerationStrategy =
+			new SingleStepOutputGenerationStrategy();
 		
 		for (int nCurrentNumber = myLoopInitializer.getLoopInitializationPoint(); myLoopCondition.evaluateLoop(nCurrentNumber, myLoopFinalizer.getLoopFinalizationPoint()); nCurrentNumber = myLoopStep.stepLoop(nCurrentNumber)) {
-			if (myFizzStrategy.isEvenlyDivisible(nCurrentNumber)) { 
-				myFizzStringPrinter.print();
-			}
-			if (myBuzzStrategy.isEvenlyDivisible(nCurrentNumber)) { 
-				myBuzzStringPrinter.print();
-			}
-			if (myNoFizzNoBuzzStrategy.isEvenlyDivisible(nCurrentNumber)) {
-				myIntIntegerPrinter.printInteger(nCurrentNumber);
-			}
-			myNewLinePrinter.print();
+			myGenerationStrategy.performGenerationForCurrentStep(nCurrentNumber);
 		}
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SingleStepOutputGenerationStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SingleStepOutputGenerationStrategy.java
@@ -1,0 +1,62 @@
+package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies;
+
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.BuzzStrategyFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.BuzzStringPrinterFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.FizzStrategyFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.FizzStringPrinterFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.IntIntegerPrinterFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.factories.IntegerPrinterFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.factories.IsEvenlyDivisibleStrategyFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.NewLineStringPrinterFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.NoFizzNoBuzzStrategyFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.factories.StringPrinterFactory;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.printers.IntegerPrinter;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.printers.StringPrinter;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.IsEvenlyDivisibleStrategy;
+
+public class SingleStepOutputGenerationStrategy {
+
+	private IsEvenlyDivisibleStrategy myFizzStrategy;
+	private StringPrinter myFizzStringPrinter;
+
+	private IsEvenlyDivisibleStrategy myBuzzStrategy;
+	private StringPrinter myBuzzStringPrinter;
+
+	private IsEvenlyDivisibleStrategy myNoFizzNoBuzzStrategy;
+	private IntegerPrinter myIntIntegerPrinter;
+
+	private StringPrinter myNewLinePrinter;
+
+	public SingleStepOutputGenerationStrategy() {
+		IsEvenlyDivisibleStrategyFactory myFizzStrategyFactory = new FizzStrategyFactory();
+		myFizzStrategy = myFizzStrategyFactory.createIsEvenlyDivisibleStrategy();
+		StringPrinterFactory myFizzStringPrinterFactory = new FizzStringPrinterFactory();
+		myFizzStringPrinter = myFizzStringPrinterFactory.createStringPrinter();
+
+		IsEvenlyDivisibleStrategyFactory myBuzzStrategyFactory = new BuzzStrategyFactory();
+		myBuzzStrategy = myBuzzStrategyFactory.createIsEvenlyDivisibleStrategy();
+		StringPrinterFactory myBuzzStringPrinterFactory = new BuzzStringPrinterFactory();
+		myBuzzStringPrinter = myBuzzStringPrinterFactory.createStringPrinter();
+
+		IsEvenlyDivisibleStrategyFactory myNoFizzNoBuzzStrategyFactory = new NoFizzNoBuzzStrategyFactory();
+		myNoFizzNoBuzzStrategy = myNoFizzNoBuzzStrategyFactory.createIsEvenlyDivisibleStrategy();
+		IntegerPrinterFactory myIntIntegerPrinterFactory = new IntIntegerPrinterFactory();
+		myIntIntegerPrinter = myIntIntegerPrinterFactory.createPrinter();
+
+		StringPrinterFactory myNewLineStringPrinterFactory = new NewLineStringPrinterFactory();
+		myNewLinePrinter = myNewLineStringPrinterFactory.createStringPrinter();
+	}
+
+	public void performGenerationForCurrentStep(int nCurrentStepNumber) {
+		if (myFizzStrategy.isEvenlyDivisible(nCurrentStepNumber)) {
+			myFizzStringPrinter.print();
+		}
+		if (myBuzzStrategy.isEvenlyDivisible(nCurrentStepNumber)) {
+			myBuzzStringPrinter.print();
+		}
+		if (myNoFizzNoBuzzStrategy.isEvenlyDivisible(nCurrentStepNumber)) {
+			myIntIntegerPrinter.printInteger(nCurrentStepNumber);
+		}
+		myNewLinePrinter.print();
+	}
+}


### PR DESCRIPTION
Currently the enterprise grade stuff for generating output is heavily mixed with enterprise grade for running the loop. This makes code much harder to maintain. Also factories are persisted long after they are not needed anymore which is likely to cause JVM memory issues in widely used enterprise Java implementations.

This fixes it all - generation is factored out and factories are only persisted while they are needed.
