### PR TITLE
Fixed compilation errors, stop breaking prod

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/adapters/LoopContextStateRetrievalToSingleStepOutputGenerationAdapter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/adapters/LoopContextStateRetrievalToSingleStepOutputGenerationAdapter.java
@@ -7,7 +7,7 @@ public class LoopContextStateRetrievalToSingleStepOutputGenerationAdapter implem
 
 	private LoopContextStateRetrieval myRetrievalObjectToAdapt;
 
-	public LoopContextStateRetrievalToSingleStepOutputGenerationAdapter(LoopContextStepRetrieval retrievalToAdapt) {
+	public LoopContextStateRetrievalToSingleStepOutputGenerationAdapter(LoopContextStateRetrieval retrievalToAdapt) {
 		myRetrievalObjectToAdapt = retrievalToAdapt;
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopContextStateManipulation.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopContextStateManipulation.java
@@ -1,6 +1,6 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.loop;
 
-public interface LoopContextStateManipuation {
+public interface LoopContextStateManipulation {
 
 	public void start();
 	public boolean shouldProceed();


### PR DESCRIPTION
Fixed compilation errors due to misspellings with
LoopContextStateRetrievalToSingleStepOutputGenerationAdapter and
LoopContextStateManipulation.
