### PR TITLE
Update .gitignore for enterprise Java development tool (IDEA).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ local.properties
 # PDT-specific
 .buildpath
 
+#################
+## IDEA
+#################
+.idea/
+*.iml
 
 #################
 ## Visual Studio


### PR DESCRIPTION
This patch addresses issue 104.
