### PR TITLE
Eliminale wrong link in project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # FizzBuzzEnterpriseEdition
-[![Build Status](https://travis-ci.org/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition.png?branch=master)](https://travis-ci.org/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition)
+[![Build status][Build status image]][Build status URL]
+
+[Build status image]: https://secure.travis-ci.org/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition.png?branch=master
+[Build status URL]: http://travis-ci.org/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition
 
 Enterprise software marks a special high-grade class of software that makes
 careful use of relevant software architecture design principles to build


### PR DESCRIPTION
It is not acceptable to have broken links in enterprise software documentation.
