### PR TITLE
Make some variables which are never changed final

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/visitors/FizzBuzzOutputGenerationContext.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/visitors/FizzBuzzOutputGenerationContext.java
@@ -6,11 +6,11 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public class FizzBuzzOutputGenerationContext implements OutputGenerationContext {
 
-	private DataPrinter printer;
-	private IsEvenlyDivisibleStrategy strategy;
+	private final DataPrinter printer;
+	private final IsEvenlyDivisibleStrategy strategy;
 
-	public FizzBuzzOutputGenerationContext(IsEvenlyDivisibleStrategy strategy,
-			DataPrinter printer) {
+	public FizzBuzzOutputGenerationContext(final IsEvenlyDivisibleStrategy strategy,
+			final DataPrinter printer) {
 		super();
 		this.strategy = strategy;
 		this.printer = printer;


### PR DESCRIPTION
In making the variables final we prevent the possibility of them ever being changed (outside of abnormal situations such as reflection), hence making it easier for an enterprise developer to follow along with the code, as they know that the final variables' values will never be changed and therefore do not have to look for changes to the variables in order to find out why odd behaviour is occurring. Obviously, this is largely hypothetical and just to put developers' minds at rest as there is no way that odd behaviour could ever occur in such excellently written enterprise code.