### PR TITLE
Removed 'public' declaration in interfaces

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/FizzBuzz.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/FizzBuzz.java
@@ -5,7 +5,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.facto
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.FizzBuzzSolutionStrategy;
 
 public class FizzBuzz {
-	public void fizzBuzz(int nFizzBuzzUpperLimit) {
+	public void fizzBuzz(final int nFizzBuzzUpperLimit) {
 		final FizzBuzzSolutionStrategyFactory mySolutionStrategyFactory =
 			new EnterpriseGradeFizzBuzzSolutionStrategyFactory();
 		final FizzBuzzSolutionStrategy mySolutionStrategy =

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/factories/LoopComponentFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/factories/LoopComponentFactory.java
@@ -16,7 +16,7 @@ public class LoopComponentFactory {
 		return myLoopInitializer;
 	}
 	
-	public LoopFinalizer createLoopFinalizer(int nLoopFinalValue) {
+	public LoopFinalizer createLoopFinalizer(final int nLoopFinalValue) {
 		final LoopFinalizer myLoopFinalizer = new LoopFinalizer(nLoopFinalValue);
 		return myLoopFinalizer;
 	}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopCondition.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopCondition.java
@@ -4,7 +4,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strat
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.comparators.integercomparator.ThreeWayIntegerComparator;
 
 public class LoopCondition {
-	public boolean evaluateLoop(int nCurrentNumber, int nTotalCount) {
+	public boolean evaluateLoop(final int nCurrentNumber, final int nTotalCount) {
 		final ThreeWayIntegerComparisonResult comparisonResult = ThreeWayIntegerComparator.Compare(nCurrentNumber, nTotalCount);
 		if (comparisonResult == ThreeWayIntegerComparisonResult.FirstIsLessThanSecond) {
 			return true;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopContext.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopContext.java
@@ -12,7 +12,7 @@ public class LoopContext implements LoopContextStateManipulation, LoopContextSta
 	LoopStep myLoopStep;
 	int myCurrentControlParameterValue;
 
-	public LoopContext(int nLoopControlParameterFinalValue) {
+	public LoopContext(final int nLoopControlParameterFinalValue) {
 		final LoopComponentFactory myLoopComponentFactory = new LoopComponentFactory();
 		myLoopInitializer = myLoopComponentFactory.createLoopInitializer();
 		myLoopFinalizer = myLoopComponentFactory.createLoopFinalizer(nLoopControlParameterFinalValue);

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopFinalizer.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopFinalizer.java
@@ -4,7 +4,7 @@ public class LoopFinalizer {
 
 	private final int nStoredLoopFinalValue;
 
-	public LoopFinalizer(int nLoopFinalValue) {
+	public LoopFinalizer(final int nLoopFinalValue) {
 		nStoredLoopFinalValue = nLoopFinalValue;
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopRunner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopRunner.java
@@ -10,9 +10,9 @@ public class LoopRunner {
 	private LoopContextStateRetrieval myStateRetrieval;
 	private LoopPayloadExecution myPayload;
 
-	public LoopRunner(LoopContextStateManipulation stateManipulation,
-						LoopContextStateRetrieval stateRetrieval,
-						LoopPayloadExecution payload)
+	public LoopRunner(final LoopContextStateManipulation stateManipulation,
+						final LoopContextStateRetrieval stateRetrieval,
+						final LoopPayloadExecution payload)
 	{
 		myStateManipulation = stateManipulation;
 		myStateRetrieval = stateRetrieval;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopStep.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopStep.java
@@ -4,7 +4,7 @@ public class LoopStep {
 
 	private static final int LOOP_INC_VALUE = 1;
 	
-	public int stepLoop(int nCurrentNumber) {
+	public int stepLoop(final int nCurrentNumber) {
 		return nCurrentNumber + LoopStep.LOOP_INC_VALUE;
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/IntegerDivider.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/IntegerDivider.java
@@ -11,19 +11,19 @@ public class IntegerDivider {
 	public static final int INTEGER_DIVIDE_ZERO_VALUE = 0;
 	public static final int INTEGER_ORIGIN_ZERO_VALUE = 0;
 	
-	public static int divide(int nFirstInteger, int nSecondInteger){
-		boolean denominatorEqualsZero =
+	public static int divide(final int nFirstInteger, final int nSecondInteger){
+		final boolean denominatorEqualsZero =
 			IntegerForEqualityComparator.areTwoIntegersEqual(nSecondInteger, INTEGER_DIVIDE_ZERO_VALUE);
 		if (denominatorEqualsZero) {
 			throw new ArithmeticException("An attempt was made to divide by zero.");
-		}else{
+		} else {
 			final double dbFirstNumber = IntToDoubleConverter.Convert(nFirstInteger);
 			final double dbSecondNumber = IntToDoubleConverter.Convert(nSecondInteger);
 			final double dbQuotient = dbFirstNumber / dbSecondNumber;
 			double dbRoundedQuotient = 0;
-			if(FirstIsSmallerThanSecondDoubleComparator.FirstIsSmallerThanSecond(dbQuotient, INTEGER_ORIGIN_ZERO_VALUE)){
+			if (FirstIsSmallerThanSecondDoubleComparator.FirstIsSmallerThanSecond(dbQuotient, INTEGER_ORIGIN_ZERO_VALUE)) {
 				dbRoundedQuotient = Math.ceil(dbQuotient);
-			}else if(FirstIsLargerThanSecondDoubleComparator.FirstIsLargerThanSecond(dbQuotient, INTEGER_ORIGIN_ZERO_VALUE)){
+			} else if(FirstIsLargerThanSecondDoubleComparator.FirstIsLargerThanSecond(dbQuotient, INTEGER_ORIGIN_ZERO_VALUE)) {
 				dbRoundedQuotient = Math.floor(dbQuotient);
 			}
 			final int nIntegerQuotient = DoubleToIntConverter.Convert(dbRoundedQuotient);

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/NumberIsMultipleOfAnotherNumberVerifier.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/NumberIsMultipleOfAnotherNumberVerifier.java
@@ -3,8 +3,8 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.comparators.integercomparator.IntegerForEqualityComparator;
 
 public class NumberIsMultipleOfAnotherNumberVerifier {
-	public static boolean numberIsMultipleOfAnotherNumber(int nFirstNumber, int nSecondNumber) {
-		try{
+	public static boolean numberIsMultipleOfAnotherNumber(final int nFirstNumber, final int nSecondNumber) {
+		try {
 			final int nDivideFirstIntegerBySecondIntegerResult =
 				(IntegerDivider.divide(nFirstNumber, nSecondNumber));
 			final int nMultiplyDivisionResultBySecondIntegerResult =
@@ -14,7 +14,7 @@ public class NumberIsMultipleOfAnotherNumberVerifier {
 			} else {
 				return false;
 			}
-		} catch( ArithmeticException ae ){
+		} catch (ArithmeticException ae) {
 			return false;
 		}
 	}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/BuzzPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/BuzzPrinter.java
@@ -11,7 +11,7 @@ public class BuzzPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public BuzzPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/BuzzStringPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/BuzzStringPrinter.java
@@ -14,7 +14,7 @@ public class BuzzStringPrinter implements StringPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public BuzzStringPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 
@@ -29,7 +29,7 @@ public class BuzzStringPrinter implements StringPrinter {
 	}
 
 	@Override
-	public void printValue(Object value) {
+	public void printValue(final Object value) {
 		print();
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/FizzPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/FizzPrinter.java
@@ -11,7 +11,7 @@ public class FizzPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public FizzPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/FizzStringPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/FizzStringPrinter.java
@@ -14,7 +14,7 @@ public class FizzStringPrinter implements StringPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public FizzStringPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 
@@ -29,7 +29,7 @@ public class FizzStringPrinter implements StringPrinter {
 	}
 
 	@Override
-	public void printValue(Object value) {
+	public void printValue(final Object value) {
 		print();
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/IntPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/IntPrinter.java
@@ -12,11 +12,11 @@ public class IntPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public IntPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 
-	public void printInteger(int theInteger) {
+	public void printInteger(final int theInteger) {
 		final IntegerStringReturner myIntegerIntegerStringReturner = new IntegerIntegerStringReturner();
 		final String myIntegerString = myIntegerIntegerStringReturner
 				.getIntegerReturnString(theInteger);

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/IntegerIntegerPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/IntegerIntegerPrinter.java
@@ -14,11 +14,11 @@ public class IntegerIntegerPrinter implements IntegerPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public IntegerIntegerPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 
-	public void printInteger(int theInteger) {
+	public void printInteger(final int theInteger) {
 		final IntegerStringReturnerFactory myIntegerIntegerStringReturnerFactory = new IntegerIntegerStringReturnerFactory();
 		final IntegerStringReturner myIntegerStringReturner = myIntegerIntegerStringReturnerFactory.createIntegerStringReturner();
 		final String myIntegerString = myIntegerStringReturner.getIntegerReturnString(theInteger);
@@ -34,7 +34,7 @@ public class IntegerIntegerPrinter implements IntegerPrinter {
 	}
 
 	@Override
-	public void printValue(Object value) {
+	public void printValue(final Object value) {
 		printInteger((Integer)value);
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/NewLinePrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/NewLinePrinter.java
@@ -11,7 +11,7 @@ public class NewLinePrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 	
 	public NewLinePrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/NewLineStringPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/NewLineStringPrinter.java
@@ -14,7 +14,7 @@ public class NewLineStringPrinter implements StringPrinter {
 	private final FizzBuzzOutputStrategy outputStrategy;
 
 	public NewLineStringPrinter() {
-		FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
+		final FizzBuzzOutputStrategyFactory factory = new SystemOutFizzBuzzOutputStrategyFactory();
 		this.outputStrategy = factory.createOutputStrategy();
 	}
 
@@ -30,7 +30,7 @@ public class NewLineStringPrinter implements StringPrinter {
 	}
 
 	@Override
-	public void printValue(Object value) {
+	public void printValue(final Object value) {
 		print();
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/BuzzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/BuzzStrategy.java
@@ -5,7 +5,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strat
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.arithmetics.NumberIsMultipleOfAnotherNumberVerifier;
 
 public class BuzzStrategy implements IsEvenlyDivisibleStrategy {
-	public boolean isEvenlyDivisible(int theInteger) {
+	public boolean isEvenlyDivisible(final int theInteger) {
 		if (NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger, BuzzStrategyConstants.BUZZ_INTEGER_CONSTANT_VALUE)) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/EnterpriseGradeFizzBuzzSolutionStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/EnterpriseGradeFizzBuzzSolutionStrategy.java
@@ -7,7 +7,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.loop.
 public class EnterpriseGradeFizzBuzzSolutionStrategy implements FizzBuzzSolutionStrategy {
 
 	@Override
-	public void runSolution(int nFizzBuzzUpperLimit) {
+	public void runSolution(final int nFizzBuzzUpperLimit) {
 		final LoopContext loopContext = new LoopContext(nFizzBuzzUpperLimit);
 		final SingleStepPayload stepPayload = new SingleStepPayload();
 		final LoopRunner loopRunner = new LoopRunner(loopContext, loopContext, stepPayload);

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/FizzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/FizzStrategy.java
@@ -5,7 +5,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strat
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.arithmetics.NumberIsMultipleOfAnotherNumberVerifier;
 
 public class FizzStrategy implements IsEvenlyDivisibleStrategy {
-	public boolean isEvenlyDivisible(int theInteger) {
+	public boolean isEvenlyDivisible(final int theInteger) {
 		if (NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger, FizzStrategyConstants.FIZZ_INTEGER_CONSTANT_VALUE)) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/NoFizzNoBuzzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/NoFizzNoBuzzStrategy.java
@@ -6,7 +6,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.
 
 public class NoFizzNoBuzzStrategy implements IsEvenlyDivisibleStrategy {
 
-	public boolean isEvenlyDivisible(int theInteger) {
+	public boolean isEvenlyDivisible(final int theInteger) {
 		if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger, NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE)) {
 			if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger, NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE)) {
 				return true;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SingleStepOutputGenerationStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SingleStepOutputGenerationStrategy.java
@@ -1,9 +1,5 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.BuzzStrategyFactory;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.BuzzStringPrinterFactory;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.FizzBuzzOutputGenerationContextVisitorFactory;
@@ -22,6 +18,10 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.visitors.OutputGenerationContext;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.visitors.OutputGenerationContextVisitor;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 public class SingleStepOutputGenerationStrategy {
 
 	private List<OutputGenerationContext> contexts = new ArrayList<OutputGenerationContext>();
@@ -30,7 +30,7 @@ public class SingleStepOutputGenerationStrategy {
 	private StringPrinter myNewLinePrinter;
 
 	public SingleStepOutputGenerationStrategy() {
-		OutputGenerationContextVisitorFactory contextVisitorFactory = new FizzBuzzOutputGenerationContextVisitorFactory();
+		final OutputGenerationContextVisitorFactory contextVisitorFactory = new FizzBuzzOutputGenerationContextVisitorFactory();
 		contextVisitor = contextVisitorFactory.createVisitor();
 		final IsEvenlyDivisibleStrategyFactory myFizzStrategyFactory = new FizzStrategyFactory();
 		final StringPrinterFactory myFizzStringPrinterFactory = new FizzStringPrinterFactory();
@@ -47,11 +47,11 @@ public class SingleStepOutputGenerationStrategy {
 		final StringPrinterFactory myNewLineStringPrinterFactory = new NewLineStringPrinterFactory();
 		myNewLinePrinter = myNewLineStringPrinterFactory.createStringPrinter();	}
 
-	public void performGenerationForCurrentStep(SingleStepOutputGenerationParameter generationParameter) {
+	public void performGenerationForCurrentStep(final SingleStepOutputGenerationParameter generationParameter) {
 		final int nGenerationParameter = generationParameter.retrieveIntegerValue();
-		Iterator<OutputGenerationContext> iterator = contexts.iterator();
+		final Iterator<OutputGenerationContext> iterator = contexts.iterator();
 		while(iterator.hasNext()) {
-			OutputGenerationContext context = iterator.next();
+			final OutputGenerationContext context = iterator.next();
 			contextVisitor.visit(context, nGenerationParameter);
 		}
 		myNewLinePrinter.print();

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SingleStepPayload.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SingleStepPayload.java
@@ -13,7 +13,7 @@ public class SingleStepPayload implements LoopPayloadExecution {
 	}
 
 	@Override
-	public void runLoopPayload(LoopContextStateRetrieval stateRetrieval) {
+	public void runLoopPayload(final LoopContextStateRetrieval stateRetrieval) {
 		final LoopContextStateRetrievalToSingleStepOutputGenerationAdapter adapter =
 			new LoopContextStateRetrievalToSingleStepOutputGenerationAdapter(stateRetrieval);
 		myGenerator.performGenerationForCurrentStep(adapter);

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SystemOutFizzBuzzOutputStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/SystemOutFizzBuzzOutputStrategy.java
@@ -1,9 +1,9 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies;
 
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.FizzBuzzOutputStrategy;
+
 import java.io.IOException;
 import java.io.OutputStream;
-
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.FizzBuzzOutputStrategy;
 
 public class SystemOutFizzBuzzOutputStrategy implements FizzBuzzOutputStrategy {
 
@@ -14,7 +14,7 @@ public class SystemOutFizzBuzzOutputStrategy implements FizzBuzzOutputStrategy {
 	}
 
 	@Override
-	public void output(String output) throws IOException {
+	public void output(final String output) throws IOException {
 
 		outputStream.write(output.getBytes());
 		outputStream.flush();

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/adapters/FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/adapters/FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter.java
@@ -6,13 +6,13 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 public class FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter implements FizzBuzzExceptionSafeOutputStrategy {
 
 	public FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter(
-				FizzBuzzOutputStrategy fizzBuzzOutputStrategyToAdapt)
+				final FizzBuzzOutputStrategy fizzBuzzOutputStrategyToAdapt)
 	{
 		myFizzBuzzOutputStrategyToAdapt = fizzBuzzOutputStrategyToAdapt;	
 	}
 
 	@Override
-	public void output(String outputStringToOutput) {
+	public void output(final String outputStringToOutput) {
 		try {
 			myFizzBuzzOutputStrategyToAdapt.output(outputStringToOutput);
 		} catch (Exception exceptionFromDoingOutput) {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/adapters/LoopContextStateRetrievalToSingleStepOutputGenerationAdapter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/adapters/LoopContextStateRetrievalToSingleStepOutputGenerationAdapter.java
@@ -7,7 +7,7 @@ public class LoopContextStateRetrievalToSingleStepOutputGenerationAdapter implem
 
 	private LoopContextStateRetrieval myRetrievalObjectToAdapt;
 
-	public LoopContextStateRetrievalToSingleStepOutputGenerationAdapter(LoopContextStateRetrieval retrievalToAdapt) {
+	public LoopContextStateRetrievalToSingleStepOutputGenerationAdapter(final LoopContextStateRetrieval retrievalToAdapt) {
 		myRetrievalObjectToAdapt = retrievalToAdapt;
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsLargerThanSecondDoubleComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsLargerThanSecondDoubleComparator.java
@@ -1,7 +1,7 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.comparators.doublecomparator;
 
 public class FirstIsLargerThanSecondDoubleComparator {
-	public static boolean FirstIsLargerThanSecond(double dbFirstDoubleToCompare, double dbSecondDoubleToCompare) {
+	public static boolean FirstIsLargerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
 		if (dbFirstDoubleToCompare > dbSecondDoubleToCompare) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsSmallerThanSecondDoubleComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsSmallerThanSecondDoubleComparator.java
@@ -1,7 +1,7 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.comparators.doublecomparator;
 
 public class FirstIsSmallerThanSecondDoubleComparator {
-	public static boolean FirstIsSmallerThanSecond(double dbFirstDoubleToCompare, double dbSecondDoubleToCompare) {
+	public static boolean FirstIsSmallerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
 		if (dbFirstDoubleToCompare < dbSecondDoubleToCompare) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
@@ -1,8 +1,8 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.comparators.integercomparator;
 
 public class IntegerForEqualityComparator {
-	public static boolean areTwoIntegersEqual(int nFirstInteger, int nSecondInteger) {
-		ThreeWayIntegerComparisonResult comparisonResult =
+	public static boolean areTwoIntegersEqual(final int nFirstInteger, final int nSecondInteger) {
+		final ThreeWayIntegerComparisonResult comparisonResult =
 			ThreeWayIntegerComparator.Compare(nFirstInteger, nSecondInteger);
 		if (comparisonResult == ThreeWayIntegerComparisonResult.FirstEqualsSecond) {
 			return true;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
@@ -1,7 +1,7 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.comparators.integercomparator;
 
 public class ThreeWayIntegerComparator {
-	public static ThreeWayIntegerComparisonResult Compare(int nFirstInteger, int nSecondInteger) {
+	public static ThreeWayIntegerComparisonResult Compare(final int nFirstInteger, final int nSecondInteger) {
 		if (nFirstInteger == nSecondInteger) {
 			return ThreeWayIntegerComparisonResult.FirstEqualsSecond;
 		} else if (nFirstInteger < nSecondInteger) {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
@@ -1,8 +1,8 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.converters.primitivetypesconverters;
 
 public class DoubleToIntConverter {
-	public static int Convert(double dbDoubleToConvert) {
-		int nConversionResult = (int) dbDoubleToConvert;
+	public static int Convert(final double dbDoubleToConvert) {
+		final int nConversionResult = (int) dbDoubleToConvert;
 		return nConversionResult;
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
@@ -1,8 +1,8 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.converters.primitivetypesconverters;
 
 public class IntToDoubleConverter {
-	public static double Convert(int nIntegerToConvert) {
-		double dbConversionResult = (double) nIntegerToConvert;
+	public static double Convert(final int nIntegerToConvert) {
+		final double dbConversionResult = (double) nIntegerToConvert;
 		return dbConversionResult;
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/IntegerIntegerStringReturner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/IntegerIntegerStringReturner.java
@@ -4,7 +4,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public class IntegerIntegerStringReturner implements IntegerStringReturner {
 
-	public String getIntegerReturnString(int theInteger) {
+	public String getIntegerReturnString(final int theInteger) {
 		final Integer myIntegerToBeConvertedToString = new Integer(theInteger);
 		final StringBuilder myStringBuilder = new StringBuilder(myIntegerToBeConvertedToString.toString());
 		final String myResultingStringFromIntegerToStringConversion = myStringBuilder.toString();

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/visitors/FizzBuzzOutputGenerationContext.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/visitors/FizzBuzzOutputGenerationContext.java
@@ -9,8 +9,8 @@ public class FizzBuzzOutputGenerationContext implements OutputGenerationContext 
 	private DataPrinter printer;
 	private IsEvenlyDivisibleStrategy strategy;
 
-	public FizzBuzzOutputGenerationContext(IsEvenlyDivisibleStrategy strategy,
-			DataPrinter printer) {
+	public FizzBuzzOutputGenerationContext(final IsEvenlyDivisibleStrategy strategy,
+			final DataPrinter printer) {
 		super();
 		this.strategy = strategy;
 		this.printer = printer;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/visitors/FizzBuzzOutputGenerationContextVisitor.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/visitors/FizzBuzzOutputGenerationContextVisitor.java
@@ -7,7 +7,7 @@ public class FizzBuzzOutputGenerationContextVisitor implements
 		OutputGenerationContextVisitor {
 
 	@Override
-	public void visit(OutputGenerationContext context, int nGenerationParameter) {
+	public void visit(final OutputGenerationContext context, final int nGenerationParameter) {
 		if (context.getStrategy().isEvenlyDivisible(nGenerationParameter)) {
 			context.getPrinter().printValue(new Integer(nGenerationParameter));
 		}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/FizzBuzzOutputStrategyFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/FizzBuzzOutputStrategyFactory.java
@@ -4,6 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface FizzBuzzOutputStrategyFactory {
 	
-	public FizzBuzzOutputStrategy createOutputStrategy();
+	FizzBuzzOutputStrategy createOutputStrategy();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/FizzBuzzSolutionStrategyFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/FizzBuzzSolutionStrategyFactory.java
@@ -4,6 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface FizzBuzzSolutionStrategyFactory {
 
-	public FizzBuzzSolutionStrategy createFizzBuzzSolutionStrategy();
+	FizzBuzzSolutionStrategy createFizzBuzzSolutionStrategy();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/IntegerPrinterFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/IntegerPrinterFactory.java
@@ -4,6 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface IntegerPrinterFactory {
 	
-	public IntegerPrinter createPrinter();
-	
+	IntegerPrinter createPrinter();
+
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/IntegerStringReturnerFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/IntegerStringReturnerFactory.java
@@ -4,6 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface IntegerStringReturnerFactory {
 	
-	public IntegerStringReturner createIntegerStringReturner();
-	
+	IntegerStringReturner createIntegerStringReturner();
+
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/IsEvenlyDivisibleStrategyFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/IsEvenlyDivisibleStrategyFactory.java
@@ -4,5 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface IsEvenlyDivisibleStrategyFactory {
 	
-	public IsEvenlyDivisibleStrategy createIsEvenlyDivisibleStrategy();
+	IsEvenlyDivisibleStrategy createIsEvenlyDivisibleStrategy();
+
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/OutputGenerationContextVisitorFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/OutputGenerationContextVisitorFactory.java
@@ -3,5 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.visitors.OutputGenerationContextVisitor;
 
 public interface OutputGenerationContextVisitorFactory {
-	public OutputGenerationContextVisitor createVisitor();
+
+	OutputGenerationContextVisitor createVisitor();
+
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/StringPrinterFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/StringPrinterFactory.java
@@ -4,6 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface StringPrinterFactory {
 	
-	public StringPrinter createStringPrinter();
-	
+	StringPrinter createStringPrinter();
+
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/StringStringReturnerFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/factories/StringStringReturnerFactory.java
@@ -4,6 +4,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 
 public interface StringStringReturnerFactory {
 
-	public StringStringReturner createStringStringReturner();
-	
+	StringStringReturner createStringStringReturner();
+
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopContextStateManipulation.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopContextStateManipulation.java
@@ -2,8 +2,8 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface LoopContextStateManipulation {
 
-	public void start();
-	public boolean shouldProceed();
-	public void proceed();
+	void start();
+	boolean shouldProceed();
+	void proceed();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopContextStateRetrieval.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopContextStateRetrieval.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface LoopContextStateRetrieval {
 
-	public int getControlParameter();
+	int getControlParameter();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopPayloadExecution.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/loop/LoopPayloadExecution.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface LoopPayloadExecution {
 
-	public void runLoopPayload(LoopContextStateRetrieval stateRetrieval);
+	void runLoopPayload(LoopContextStateRetrieval stateRetrieval);
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/parameters/FizzBuzzUpperLimitParameter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/parameters/FizzBuzzUpperLimitParameter.java
@@ -2,6 +2,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface FizzBuzzUpperLimitParameter {
 
-	public int ObtainUpperLimitValue();
+	int ObtainUpperLimitValue();
+
 }
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/printers/DataPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/printers/DataPrinter.java
@@ -1,7 +1,9 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.printers;
 
 public interface DataPrinter {
-	public void print();
-	public void printValue(Object value);
+
+	void print();
+	void printValue(Object value);
+
 }
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/printers/IntegerPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/printers/IntegerPrinter.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface IntegerPrinter extends DataPrinter {
 
-	public void printInteger(int theInteger);
+	void printInteger(int theInteger);
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/printers/StringPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/printers/StringPrinter.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface StringPrinter extends DataPrinter {
 
-	public void print();
+	void print();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/FizzBuzzExceptionSafeOutputStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/FizzBuzzExceptionSafeOutputStrategy.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface FizzBuzzExceptionSafeOutputStrategy {
 
-	public void output(String output);
+	void output(String output);
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/FizzBuzzOutputStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/FizzBuzzOutputStrategy.java
@@ -4,6 +4,6 @@ import java.io.IOException;
 
 public interface FizzBuzzOutputStrategy {
 	
-	public void output(String output) throws IOException;
+	void output(String output) throws IOException;
 	
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/FizzBuzzSolutionStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/FizzBuzzSolutionStrategy.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface FizzBuzzSolutionStrategy {
 
-	public void runSolution(int nFizzBuzzUpperLimit);
+	void runSolution(int nFizzBuzzUpperLimit);
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/IsEvenlyDivisibleStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/IsEvenlyDivisibleStrategy.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface IsEvenlyDivisibleStrategy {
 	
-	public boolean isEvenlyDivisible(int theInteger);
+	boolean isEvenlyDivisible(int theInteger);
 	
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/SingleStepOutputGenerationParameter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/strategies/SingleStepOutputGenerationParameter.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface SingleStepOutputGenerationParameter {
 
-	public int retrieveIntegerValue();
+	int retrieveIntegerValue();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/stringreturners/IntegerStringReturner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/stringreturners/IntegerStringReturner.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface IntegerStringReturner {
 	
-	public String getIntegerReturnString(int theInteger);
+	String getIntegerReturnString(int theInteger);
 	
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/stringreturners/StringStringReturner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/stringreturners/StringStringReturner.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface StringStringReturner {
 	
-	public String getReturnString();
+	String getReturnString();
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/visitors/OutputGenerationContext.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/visitors/OutputGenerationContext.java
@@ -4,7 +4,9 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.IsEvenlyDivisibleStrategy;
 
 public interface OutputGenerationContext {
-	public IsEvenlyDivisibleStrategy getStrategy();
-	public DataPrinter getPrinter();
+
+	IsEvenlyDivisibleStrategy getStrategy();
+	DataPrinter getPrinter();
+
 }
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/visitors/OutputGenerationContextVisitor.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/visitors/OutputGenerationContextVisitor.java
@@ -1,6 +1,8 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.visitors;
 
 public interface OutputGenerationContextVisitor {
-	public void visit(OutputGenerationContext context, int nGenerationParameter);
+
+	void visit(OutputGenerationContext context, int nGenerationParameter);
+
 }
 


### PR DESCRIPTION
The 'public' method declaration in an interface is not needed, since they are public by default.