### PR TITLE
Code style violation

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/parameters/FizzBuzzUpperLimitParameter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/interfaces/parameters/FizzBuzzUpperLimitParameter.java
@@ -2,6 +2,6 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interface
 
 public interface FizzBuzzUpperLimitParameter {
 
-	public int ObtainUpperLimitValue();
+	public int obtainUpperLimitValue();
 }
 


### PR DESCRIPTION
This is not acceptable in a serious environment. Methods must start with lower case letters.