### PR TITLE
Change ordering of if-statements in readme for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ showing the programmer understands basic, necessary tools such as
 
 For numbers 1 through 100,
 
-* if the number is divisible by 3 print Fizz;
-* if the number is divisible by 5 print Buzz;
-* if the number is divisible by 3 and 5 (15) print FizzBuzz;
+* if the number is divisible by 3 and 5 (15), print FizzBuzz;
+* else, if the number is divisible by 3, print Fizz;
+* else, if the number is divisible by 5, print Buzz;
 * else, print the number.


### PR DESCRIPTION
The requirements are unclear in the readme. A number that is divisible by 3 is also divisible by 3 and 5.
It is possible to misinterpret this and never print Fizzbuzz as a result, since printing Fizz instead is also in accord with the given description.
To help clear up these ambiguities, and to avoid disarray, this tested and code-reviewed (by fellow enterprise developers) pull request - which also has some grammatical improvements - should be merged.
