### PR TITLE
Add unsupported platform files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,10 @@ Thumbs.db
 # Folder config file
 Desktop.ini
 
+#############
+## Mac OS
+#############
+.DS_Store
 
 #############
 ## Python


### PR DESCRIPTION
Even though Mac isn't supported yet it might be in the future so we should ignore the hidden folder information files just in case.