### PR TITLE
squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
@@ -9,6 +9,8 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.parameters.DefaultFizzBuzzUpperLimitParameter;
 
 public final class Main {
+	
+	private Main () {}
 
 	public static void main(final String[] args) {
 		final ApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopCondition.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopCondition.java
@@ -13,10 +13,7 @@ public class LoopCondition {
 				nTotalCount);
 		if (comparisonResult == ThreeWayIntegerComparisonResult.FirstIsLessThanSecond) {
 			return true;
-		} else if (comparisonResult == ThreeWayIntegerComparisonResult.FirstEqualsSecond) {
-			return true;
-		} else {
-			return false;
 		}
+		return comparisonResult == ThreeWayIntegerComparisonResult.FirstEqualsSecond;
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopCondition.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/loop/LoopCondition.java
@@ -9,7 +9,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strat
 public class LoopCondition {
 
 	public boolean evaluateLoop(final int nCurrentNumber, final int nTotalCount) {
-		final ThreeWayIntegerComparisonResult comparisonResult = ThreeWayIntegerComparator.Compare(nCurrentNumber,
+		final ThreeWayIntegerComparisonResult comparisonResult = ThreeWayIntegerComparator.compare(nCurrentNumber,
 				nTotalCount);
 		if (comparisonResult == ThreeWayIntegerComparisonResult.FirstIsLessThanSecond) {
 			return true;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/IntegerDivider.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/IntegerDivider.java
@@ -31,18 +31,18 @@ public class IntegerDivider {
 		if (denominatorEqualsZero) {
 			throw new ArithmeticException("An attempt was made to divide by zero.");
 		} else {
-			final double dbFirstNumber = IntToDoubleConverter.Convert(nFirstInteger);
-			final double dbSecondNumber = IntToDoubleConverter.Convert(nSecondInteger);
+			final double dbFirstNumber = IntToDoubleConverter.convert(nFirstInteger);
+			final double dbSecondNumber = IntToDoubleConverter.convert(nSecondInteger);
 			final double dbQuotient = dbFirstNumber / dbSecondNumber;
 			double dbRoundedQuotient = (double) IntegerDivider.INTEGER_ORIGIN_ZERO_VALUE;
-			if (this.firstIsSmallerThanSecondDoubleComparator.FirstIsSmallerThanSecond(dbQuotient,
+			if (this.firstIsSmallerThanSecondDoubleComparator.firstIsSmallerThanSecond(dbQuotient,
 					(double) IntegerDivider.INTEGER_ORIGIN_ZERO_VALUE)) {
 				dbRoundedQuotient = Math.ceil(dbQuotient);
-			} else if (this.firstIsLargerThanSecondDoubleComparator.FirstIsLargerThanSecond(dbQuotient,
+			} else if (this.firstIsLargerThanSecondDoubleComparator.firstIsLargerThanSecond(dbQuotient,
 					(double) IntegerDivider.INTEGER_ORIGIN_ZERO_VALUE)) {
 				dbRoundedQuotient = Math.floor(dbQuotient);
 			}
-			final int nIntegerQuotient = DoubleToIntConverter.Convert(dbRoundedQuotient);
+			final int nIntegerQuotient = DoubleToIntConverter.convert(dbRoundedQuotient);
 			return nIntegerQuotient;
 		}
 	}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/NumberIsMultipleOfAnotherNumberVerifier.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/NumberIsMultipleOfAnotherNumberVerifier.java
@@ -24,12 +24,8 @@ public class NumberIsMultipleOfAnotherNumberVerifier {
 					(NumberIsMultipleOfAnotherNumberVerifier.integerDivider.divide(nFirstNumber, nSecondNumber));
 			final int nMultiplyDivisionResultBySecondIntegerResult =
 					nDivideFirstIntegerBySecondIntegerResult * nSecondNumber;
-			if (IntegerForEqualityComparator.areTwoIntegersEqual(nMultiplyDivisionResultBySecondIntegerResult,
-					nFirstNumber)) {
-				return true;
-			} else {
-				return false;
-			}
+			return IntegerForEqualityComparator.areTwoIntegersEqual(nMultiplyDivisionResultBySecondIntegerResult, nFirstNumber);
+			
 		} catch (final ArithmeticException ae) {
 			return false;
 		}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/BuzzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/BuzzStrategy.java
@@ -10,11 +10,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.
 public class BuzzStrategy implements IsEvenlyDivisibleStrategy {
 
 	public boolean isEvenlyDivisible(final int theInteger) {
-		if (NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-				BuzzStrategyConstants.BUZZ_INTEGER_CONSTANT_VALUE)) {
-			return true;
-		} else {
-			return false;
-		}
+		return NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
+				BuzzStrategyConstants.BUZZ_INTEGER_CONSTANT_VALUE);
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/FizzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/FizzStrategy.java
@@ -10,11 +10,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.
 public class FizzStrategy implements IsEvenlyDivisibleStrategy {
 
 	public boolean isEvenlyDivisible(final int theInteger) {
-		if (NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-				FizzStrategyConstants.FIZZ_INTEGER_CONSTANT_VALUE)) {
-			return true;
-		} else {
-			return false;
-		}
+		return NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
+				FizzStrategyConstants.FIZZ_INTEGER_CONSTANT_VALUE);
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/NoFizzNoBuzzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/NoFizzNoBuzzStrategy.java
@@ -12,20 +12,12 @@ public class NoFizzNoBuzzStrategy implements IsEvenlyDivisibleStrategy {
 	public boolean isEvenlyDivisible(final int theInteger) {
 		if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
 				NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE)) {
-			if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-					NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE)) {
-				return true;
-			} else {
-				return false;
-			}
+			return !NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
+					NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE);
 		} else if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
 				NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE)) {
-			if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-					NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE)) {
-				return true;
-			} else {
-				return false;
-			}
+			return !NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
+					NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE);
 		} else {
 			return false;
 		}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsLargerThanSecondDoubleComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsLargerThanSecondDoubleComparator.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class FirstIsLargerThanSecondDoubleComparator {
-	public  boolean FirstIsLargerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
+	public  boolean firstIsLargerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
 		if (dbFirstDoubleToCompare > dbSecondDoubleToCompare) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsLargerThanSecondDoubleComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsLargerThanSecondDoubleComparator.java
@@ -5,10 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class FirstIsLargerThanSecondDoubleComparator {
 	public  boolean firstIsLargerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
-		if (dbFirstDoubleToCompare > dbSecondDoubleToCompare) {
-			return true;
-		} else {
-			return false;
-		}
+		return dbFirstDoubleToCompare > dbSecondDoubleToCompare;
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsSmallerThanSecondDoubleComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsSmallerThanSecondDoubleComparator.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class FirstIsSmallerThanSecondDoubleComparator {
-	public  boolean FirstIsSmallerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
+	public  boolean firstIsSmallerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
 		if (dbFirstDoubleToCompare < dbSecondDoubleToCompare) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsSmallerThanSecondDoubleComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/doublecomparator/FirstIsSmallerThanSecondDoubleComparator.java
@@ -5,10 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class FirstIsSmallerThanSecondDoubleComparator {
 	public  boolean firstIsSmallerThanSecond(final double dbFirstDoubleToCompare, final double dbSecondDoubleToCompare) {
-		if (dbFirstDoubleToCompare < dbSecondDoubleToCompare) {
-			return true;
-		} else {
-			return false;
-		}
+		return dbFirstDoubleToCompare < dbSecondDoubleToCompare;
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class IntegerForEqualityComparator {
+	
+	private IntegerForEqualityComparator() {}
 
 	public static boolean areTwoIntegersEqual(final int nFirstInteger, final int nSecondInteger) {
 		final ThreeWayIntegerComparisonResult comparisonResult =

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
@@ -9,7 +9,7 @@ public class IntegerForEqualityComparator {
 
 	public static boolean areTwoIntegersEqual(final int nFirstInteger, final int nSecondInteger) {
 		final ThreeWayIntegerComparisonResult comparisonResult =
-				ThreeWayIntegerComparator.Compare(nFirstInteger, nSecondInteger);
+				ThreeWayIntegerComparator.compare(nFirstInteger, nSecondInteger);
 		if (comparisonResult == ThreeWayIntegerComparisonResult.FirstEqualsSecond) {
 			return true;
 		} else {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
@@ -10,10 +10,6 @@ public class IntegerForEqualityComparator {
 	public static boolean areTwoIntegersEqual(final int nFirstInteger, final int nSecondInteger) {
 		final ThreeWayIntegerComparisonResult comparisonResult =
 				ThreeWayIntegerComparator.compare(nFirstInteger, nSecondInteger);
-		if (comparisonResult == ThreeWayIntegerComparisonResult.FirstEqualsSecond) {
-			return true;
-		} else {
-			return false;
-		}
+		return comparisonResult == ThreeWayIntegerComparisonResult.FirstEqualsSecond;
 	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
@@ -7,7 +7,7 @@ public class ThreeWayIntegerComparator {
 	
 	private ThreeWayIntegerComparator() {}
 
-	public static ThreeWayIntegerComparisonResult Compare(final int nFirstInteger, final int nSecondInteger) {
+	public static ThreeWayIntegerComparisonResult compare(final int nFirstInteger, final int nSecondInteger) {
 		if (nFirstInteger == nSecondInteger) {
 			return ThreeWayIntegerComparisonResult.FirstEqualsSecond;
 		} else if (nFirstInteger < nSecondInteger) {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ThreeWayIntegerComparator {
+	
+	private ThreeWayIntegerComparator() {}
 
 	public static ThreeWayIntegerComparisonResult Compare(final int nFirstInteger, final int nSecondInteger) {
 		if (nFirstInteger == nSecondInteger) {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/BuzzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/BuzzStrategyConstants.java
@@ -5,5 +5,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class BuzzStrategyConstants
 {
+	private BuzzStrategyConstants() {}
+	
 	public static final int BUZZ_INTEGER_CONSTANT_VALUE = 5;
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/FizzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/FizzStrategyConstants.java
@@ -5,5 +5,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class FizzStrategyConstants
 {
+	private FizzStrategyConstants() {}
+
 	public static final int FIZZ_INTEGER_CONSTANT_VALUE = 3;
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/NoFizzNoBuzzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/NoFizzNoBuzzStrategyConstants.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class NoFizzNoBuzzStrategyConstants
 {
+	private NoFizzNoBuzzStrategyConstants() {}
+	
 	public static final int NO_BUZZ_INTEGER_CONSTANT_VALUE = BuzzStrategyConstants.BUZZ_INTEGER_CONSTANT_VALUE;
 	public static final int NO_FIZZ_INTEGER_CONSTANT_VALUE = FizzStrategyConstants.FIZZ_INTEGER_CONSTANT_VALUE;
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
@@ -7,7 +7,7 @@ public class DoubleToIntConverter {
 
 	private DoubleToIntConverter() {}
 
-	public static int Convert(final double dbDoubleToConvert) {
+	public static int convert(final double dbDoubleToConvert) {
 		final int nConversionResult = (int) dbDoubleToConvert;
 		return nConversionResult;
 	}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DoubleToIntConverter {
+
+	private DoubleToIntConverter() {}
+
 	public static int Convert(final double dbDoubleToConvert) {
 		final int nConversionResult = (int) dbDoubleToConvert;
 		return nConversionResult;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
@@ -7,7 +7,7 @@ public class IntToDoubleConverter {
 
 	private IntToDoubleConverter() {}
 
-	public static double Convert(final int nIntegerToConvert) {
+	public static double convert(final int nIntegerToConvert) {
 		final double dbConversionResult = (double) nIntegerToConvert;
 		return dbConversionResult;
 	}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class IntToDoubleConverter {
 
+	private IntToDoubleConverter() {}
+
 	public static double Convert(final int nIntegerToConvert) {
 		final double dbConversionResult = (double) nIntegerToConvert;
 		return dbConversionResult;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1126 - Return of boolean expressions should not be wrapped into an "if-then-else" statement.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1126
Please let me know if you have any questions.
George Kankava
