### PR TITLE
squid:S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
@@ -9,6 +9,8 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.parameters.DefaultFizzBuzzUpperLimitParameter;
 
 public final class Main {
+	
+	private Main () {}
 
 	public static void main(final String[] args) {
 		final ApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
@@ -10,8 +10,6 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.param
 
 public final class Main {
 	
-	private Main () {}
-
 	public static void main(final String[] args) {
 		final ApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");
 		final FizzBuzz myFizzBuzz = (FizzBuzz) context.getBean("standardFizzBuzz");

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/Main.java
@@ -9,7 +9,7 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.parameters.DefaultFizzBuzzUpperLimitParameter;
 
 public final class Main {
-	
+
 	public static void main(final String[] args) {
 		final ApplicationContext context = new ClassPathXmlApplicationContext("spring.xml");
 		final FizzBuzz myFizzBuzz = (FizzBuzz) context.getBean("standardFizzBuzz");

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class IntegerForEqualityComparator {
+public final class IntegerForEqualityComparator {
 	
 	private IntegerForEqualityComparator() {}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/IntegerForEqualityComparator.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class IntegerForEqualityComparator {
+	
+	private IntegerForEqualityComparator() {}
 
 	public static boolean areTwoIntegersEqual(final int nFirstInteger, final int nSecondInteger) {
 		final ThreeWayIntegerComparisonResult comparisonResult =

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class ThreeWayIntegerComparator {
+public final class ThreeWayIntegerComparator {
 	
 	private ThreeWayIntegerComparator() {}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/comparators/integercomparator/ThreeWayIntegerComparator.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ThreeWayIntegerComparator {
+	
+	private ThreeWayIntegerComparator() {}
 
 	public static ThreeWayIntegerComparisonResult Compare(final int nFirstInteger, final int nSecondInteger) {
 		if (nFirstInteger == nSecondInteger) {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/BuzzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/BuzzStrategyConstants.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class BuzzStrategyConstants
+public final class BuzzStrategyConstants
 {
 	private BuzzStrategyConstants() {}
 	

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/BuzzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/BuzzStrategyConstants.java
@@ -5,5 +5,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class BuzzStrategyConstants
 {
+	private BuzzStrategyConstants() {}
+	
 	public static final int BUZZ_INTEGER_CONSTANT_VALUE = 5;
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/FizzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/FizzStrategyConstants.java
@@ -5,5 +5,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class FizzStrategyConstants
 {
+	private FizzStrategyConstants() {}
+
 	public static final int FIZZ_INTEGER_CONSTANT_VALUE = 3;
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/FizzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/FizzStrategyConstants.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class FizzStrategyConstants
+public final class FizzStrategyConstants
 {
 	private FizzStrategyConstants() {}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/NoFizzNoBuzzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/NoFizzNoBuzzStrategyConstants.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class NoFizzNoBuzzStrategyConstants
 {
+	private NoFizzNoBuzzStrategyConstants() {}
+	
 	public static final int NO_BUZZ_INTEGER_CONSTANT_VALUE = BuzzStrategyConstants.BUZZ_INTEGER_CONSTANT_VALUE;
 	public static final int NO_FIZZ_INTEGER_CONSTANT_VALUE = FizzStrategyConstants.FIZZ_INTEGER_CONSTANT_VALUE;
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/NoFizzNoBuzzStrategyConstants.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/constants/NoFizzNoBuzzStrategyConstants.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class NoFizzNoBuzzStrategyConstants
+public final class NoFizzNoBuzzStrategyConstants
 {
 	private NoFizzNoBuzzStrategyConstants() {}
 	

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
@@ -4,6 +4,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class DoubleToIntConverter {
+
+	private DoubleToIntConverter() {}
+
 	public static int Convert(final double dbDoubleToConvert) {
 		final int nConversionResult = (int) dbDoubleToConvert;
 		return nConversionResult;

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/DoubleToIntConverter.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class DoubleToIntConverter {
+public final class DoubleToIntConverter {
 
 	private DoubleToIntConverter() {}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
@@ -3,7 +3,7 @@ package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stra
 import org.springframework.stereotype.Service;
 
 @Service
-public class IntToDoubleConverter {
+public final class IntToDoubleConverter {
 
 	private IntToDoubleConverter() {}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/converters/primitivetypesconverters/IntToDoubleConverter.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class IntToDoubleConverter {
 
+	private IntToDoubleConverter() {}
+
 	public static double Convert(final int nIntegerToConvert) {
 		final double dbConversionResult = (double) nIntegerToConvert;
 		return dbConversionResult;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava
