### PR TITLE
FindBugs fix; Windows build fix.

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/ApplicationContextHolder.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/ApplicationContextHolder.java
@@ -9,13 +9,24 @@ import org.springframework.stereotype.Service;
 public class ApplicationContextHolder implements ApplicationContextAware {
 
 	private static ApplicationContext applicationContext;
+	
+	private static class ApplicationContextReferenceUpdater {
+	    void updateApplicationContextReference(final ApplicationContext applicationContext) {
+	        ApplicationContextHolder.applicationContext = applicationContext;
+	    }
+	}
+	
+	private static class ApplicationContextReferenceUpdaterHolder {
+	    static ApplicationContextReferenceUpdater INSTANCE = new ApplicationContextReferenceUpdater();
+	}
 
 	private ApplicationContextHolder() {
 		super();
 	}
 
-	public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
-		ApplicationContextHolder.applicationContext = applicationContext;
+	@Override
+    public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
+		ApplicationContextReferenceUpdaterHolder.INSTANCE.updateApplicationContextReference(applicationContext);
 	}
 
 	public static ApplicationContext getApplicationContext() {

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/ApplicationContextHolder.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/ApplicationContextHolder.java
@@ -9,15 +9,15 @@ import org.springframework.stereotype.Service;
 public class ApplicationContextHolder implements ApplicationContextAware {
 
 	private static ApplicationContext applicationContext;
-	
+
 	private static class ApplicationContextReferenceUpdater {
-	    void updateApplicationContextReference(final ApplicationContext applicationContext) {
-	        ApplicationContextHolder.applicationContext = applicationContext;
-	    }
+		void updateApplicationContextReference(final ApplicationContext applicationContext) {
+			ApplicationContextHolder.applicationContext = applicationContext;
+		}
 	}
-	
+
 	private static class ApplicationContextReferenceUpdaterHolder {
-	    static ApplicationContextReferenceUpdater INSTANCE = new ApplicationContextReferenceUpdater();
+		static ApplicationContextReferenceUpdater INSTANCE = new ApplicationContextReferenceUpdater();
 	}
 
 	private ApplicationContextHolder() {
@@ -25,7 +25,7 @@ public class ApplicationContextHolder implements ApplicationContextAware {
 	}
 
 	@Override
-    public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
+	public void setApplicationContext(final ApplicationContext applicationContext) throws BeansException {
 		ApplicationContextReferenceUpdaterHolder.INSTANCE.updateApplicationContextReference(applicationContext);
 	}
 

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/BuzzPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/BuzzPrinter.java
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.SystemOutFizzBuzzOutputStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.adapters.FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stringreturners.BuzzStringReturner;
 
 @Service
 public class BuzzPrinter {
@@ -16,15 +14,6 @@ public class BuzzPrinter {
 	public BuzzPrinter(final SystemOutFizzBuzzOutputStrategyFactory _systemOutFizzBuzzOutputStrategyFactory) {
 		super();
 		this._systemOutFizzBuzzOutputStrategyFactory = _systemOutFizzBuzzOutputStrategyFactory;
-	}
-
-	public void printBuzz() {
-		final BuzzStringReturner myBuzzStringReturner = new BuzzStringReturner();
-		final FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter myOutputAdapter =
-				new FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter(
-						this._systemOutFizzBuzzOutputStrategyFactory.createOutputStrategy());
-
-		myOutputAdapter.output(myBuzzStringReturner.getReturnString());
 	}
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/FizzPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/FizzPrinter.java
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.SystemOutFizzBuzzOutputStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.adapters.FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stringreturners.FizzStringReturner;
 
 @Service
 public class FizzPrinter {
@@ -16,15 +14,6 @@ public class FizzPrinter {
 	public FizzPrinter(final SystemOutFizzBuzzOutputStrategyFactory _systemOutFizzBuzzOutputStrategyFactory) {
 		super();
 		this._systemOutFizzBuzzOutputStrategyFactory = _systemOutFizzBuzzOutputStrategyFactory;
-	}
-
-	public void printFizz() {
-		final FizzStringReturner myFizzStringReturner = new FizzStringReturner();
-		final FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter myOutputAdapter =
-				new FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter(
-						this._systemOutFizzBuzzOutputStrategyFactory.createOutputStrategy());
-
-		myOutputAdapter.output(myFizzStringReturner.getReturnString());
 	}
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/IntegerPrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/IntegerPrinter.java
@@ -4,9 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.SystemOutFizzBuzzOutputStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.adapters.FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stringreturners.IntegerIntegerStringReturner;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.stringreturners.IntegerStringReturner;
 
 @Service
 public class IntegerPrinter {
@@ -17,17 +14,6 @@ public class IntegerPrinter {
 	public IntegerPrinter(final SystemOutFizzBuzzOutputStrategyFactory _systemOutFizzBuzzOutputStrategyFactory) {
 		super();
 		this._systemOutFizzBuzzOutputStrategyFactory = _systemOutFizzBuzzOutputStrategyFactory;
-	}
-
-	public void printInteger(final int theInteger) {
-		final IntegerStringReturner myIntegerIntegerStringReturner = new IntegerIntegerStringReturner();
-		final String myIntegerString = myIntegerIntegerStringReturner
-			.getIntegerReturnString(theInteger);
-		final FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter myOutputAdapter =
-				new FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter(
-						this._systemOutFizzBuzzOutputStrategyFactory.createOutputStrategy());
-
-		myOutputAdapter.output(myIntegerString);
 	}
 
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/NewLinePrinter.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/printers/NewLinePrinter.java
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.SystemOutFizzBuzzOutputStrategyFactory;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.adapters.FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.stringreturners.NewLineStringReturner;
 
 @Service
 public class NewLinePrinter {
@@ -16,16 +14,6 @@ public class NewLinePrinter {
 	public NewLinePrinter(final SystemOutFizzBuzzOutputStrategyFactory _systemOutFizzBuzzOutputStrategyFactory) {
 		super();
 		this._systemOutFizzBuzzOutputStrategyFactory = _systemOutFizzBuzzOutputStrategyFactory;
-	}
-
-	public void printNewLine() {
-		final NewLineStringReturner myNewLineStringReturner = new NewLineStringReturner();
-		final String myNewLineString = myNewLineStringReturner.getReturnString();
-		final FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter myOutputAdapter =
-				new FizzBuzzOutputStrategyToFizzBuzzExceptionSafeOutputStrategyAdapter(
-						this._systemOutFizzBuzzOutputStrategyFactory.createOutputStrategy());
-
-		myOutputAdapter.output(myNewLineString);
 	}
 
 }

--- a/src/test/java/FizzBuzzTest.java
+++ b/src/test/java/FizzBuzzTest.java
@@ -40,7 +40,8 @@ public class FizzBuzzTest {
 		this.fb.fizzBuzz(n);
 
 		System.out.flush();
-		assertEquals(s, baos.toString());
+		final String platformDependentExpectedResult = s.replaceAll("\\n", System.getProperty("line.separator"));
+		assertEquals(platformDependentExpectedResult, baos.toString());
 	}
 
 	@Test


### PR DESCRIPTION
FindBugs flagged access to a static field from a non-static context; introduced reference updater class and singleton instance. Also added a small change to make the tests work on Windows. (Since Windows is not a sufficiently enterprise platform, you may regard this part of the PR as optional.)
