### PR TITLE
FizzStringReturner may not have copied all characters

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/FizzStringReturner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/FizzStringReturner.java
@@ -11,7 +11,8 @@ public class FizzStringReturner implements StringStringReturner {
 		final StringBuilder myStringBuilder = new StringBuilder(
 				com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.Constants.FIZZ);
 		final String myString = myStringBuilder.toString();
-		return new String(myString);
+		final char[] myCharacters = myString.toCharArray();
+		return new String(myCharacters, 0, myCharacters.length);
 	}
 
 }


### PR DESCRIPTION
I noticed that the String construtor was being called without specifying
the start offset and count. This is unacceptable. How do I know if it's
copying all the characters unless I can actually see it in the code. In
this change, you'll get the distinct air of superiority as you have now
begun dealing with low-level constructs such as arrays. As they say, rub
on some arrays, and watch the women flock.