### PR TITLE
Adding conversion to charArray in IntegerIntegerStringReturner

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/IntegerIntegerStringReturner.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/stringreturners/IntegerIntegerStringReturner.java
@@ -11,7 +11,8 @@ public class IntegerIntegerStringReturner implements IntegerStringReturner {
 		final Integer myIntegerToBeConvertedToString = new Integer(theInteger);
 		final StringBuilder myStringBuilder = new StringBuilder(myIntegerToBeConvertedToString.toString());
 		final String myResultingStringFromIntegerToStringConversion = myStringBuilder.toString();
-		return new String(myResultingStringFromIntegerToStringConversion);
-	}
+		final char[] myCharacterArrayFromIntegerToStringConversion = myResultingStringFromIntegerToStringConversion.toCharArray();
+		return new String(myCharacterArrayFromIntegerToStringConversion, 0, myCharacterArrayFromIntegerToStringConversion.length);
+		}
 
 }


### PR DESCRIPTION
According to two other string returners in this package, the convention is (constant/integer).toString-> new StringBuilder -> toString -> toCharArray -> new String.  Previous commit ignored the conversion to Character Array leading to non-uniform standards, so I've added the conversion back in.