### PR TITLE
Increase performance by computing multiply needed values lazily

### DIFF
--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/caching/LazilyComputedValue.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/caching/LazilyComputedValue.java
@@ -4,7 +4,7 @@ import java.util.function.Supplier;
 
 public class LazilyComputedValue<T> {
 
-    private final Object lockForValueComputation = new Object();
+	private final Object lockForValueComputation = new Object();
 	private volatile Supplier<T> lazyValueComputationFunction;
 	private T lazilyComputedValue;
 
@@ -13,15 +13,15 @@ public class LazilyComputedValue<T> {
 	}
 
 	public T getLazilyComputedValue() {
-	    if (lazyValueComputationFunction != null) {
-	        synchronized (lockForValueComputation) {
-	            if (lazyValueComputationFunction != null) {
-	                lazilyComputedValue = lazyValueComputationFunction.get();
-	                lazyValueComputationFunction = null;
-	                return lazilyComputedValue;
-                }
-            }
-        }
-	    return lazilyComputedValue;
-    }
+		if (lazyValueComputationFunction != null) {
+			synchronized (lockForValueComputation) {
+				if (lazyValueComputationFunction != null) {
+					lazilyComputedValue = lazyValueComputationFunction.get();
+					lazyValueComputationFunction = null;
+					return lazilyComputedValue;
+				}
+			}
+		}
+		return lazilyComputedValue;
+	}
 }

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/caching/LazilyComputedValue.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/caching/LazilyComputedValue.java
@@ -1,0 +1,27 @@
+package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.caching;
+
+import java.util.function.Supplier;
+
+public class LazilyComputedValue<T> {
+
+    private final Object lockForValueComputation = new Object();
+	private volatile Supplier<T> lazyValueComputationFunction;
+	private T lazilyComputedValue;
+
+	public LazilyComputedValue(Supplier<T> lazyValueComputationFunction) {
+		this.lazyValueComputationFunction = lazyValueComputationFunction;
+	}
+
+	public T getLazilyComputedValue() {
+	    if (lazyValueComputationFunction != null) {
+	        synchronized (lockForValueComputation) {
+	            if (lazyValueComputationFunction != null) {
+	                lazilyComputedValue = lazyValueComputationFunction.get();
+	                lazyValueComputationFunction = null;
+	                return lazilyComputedValue;
+                }
+            }
+        }
+	    return lazilyComputedValue;
+    }
+}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/factories/LazyFactory.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/factories/LazyFactory.java
@@ -1,0 +1,14 @@
+package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories;
+
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.caching.LazilyComputedValue;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LazyFactory {
+
+	public <T> LazilyComputedValue<T> createLazy(Supplier<T> lazyValueComputationFunction) {
+		return new LazilyComputedValue<>(lazyValueComputationFunction);
+	}
+
+}

--- a/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/NoFizzNoBuzzStrategy.java
+++ b/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/strategies/NoFizzNoBuzzStrategy.java
@@ -1,10 +1,12 @@
 package com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies;
 
-import org.springframework.stereotype.Service;
-
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.IsEvenlyDivisibleStrategy;
-import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.constants.NoFizzNoBuzzStrategyConstants;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.caching.LazilyComputedValue;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.factories.LazyFactory;
 import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.arithmetics.NumberIsMultipleOfAnotherNumberVerifier;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.constants.NoFizzNoBuzzStrategyConstants;
+import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.interfaces.strategies.IsEvenlyDivisibleStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 /**
  * Strategy for NoFizzNoBuzz
@@ -12,23 +14,32 @@ import com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.
 @Service
 public class NoFizzNoBuzzStrategy implements IsEvenlyDivisibleStrategy {
 
+	private final LazyFactory lazyFactory;
+
+	@Autowired
+	public NoFizzNoBuzzStrategy(LazyFactory lazyFactory) {
+		this.lazyFactory = lazyFactory;
+	}
+
 	/**
 	 * @param theInteger int
 	 * @return boolean
 	 */
 	public boolean isEvenlyDivisible(final int theInteger) {
-		if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-				NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE)) {
-			if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-					NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE)) {
+		LazilyComputedValue<Boolean> lazilyComputedIsFizzMultiple = this.lazyFactory.createLazy(
+				() -> NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
+						NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE));
+		LazilyComputedValue<Boolean> lazilyComputedIsBuzzMultiple = this.lazyFactory.createLazy(
+				() -> NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
+						NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE));
+		if (!lazilyComputedIsFizzMultiple.getLazilyComputedValue()) {
+			if (!lazilyComputedIsBuzzMultiple.getLazilyComputedValue()) {
 				return true;
 			} else {
 				return false;
 			}
-		} else if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-				NoFizzNoBuzzStrategyConstants.NO_BUZZ_INTEGER_CONSTANT_VALUE)) {
-			if (!NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(theInteger,
-					NoFizzNoBuzzStrategyConstants.NO_FIZZ_INTEGER_CONSTANT_VALUE)) {
+		} else if (!lazilyComputedIsBuzzMultiple.getLazilyComputedValue()) {
+			if (!lazilyComputedIsFizzMultiple.getLazilyComputedValue()) {
 				return true;
 			} else {
 				return false;


### PR DESCRIPTION
When I looked at the `NoFizzNoBuzzStrategy`, I noticed that it computes twice whether one number is divisible by another. Given that the involved numbers are not constants, division is one of the most expensive machine instructions, and the instruction latency varies between 7 and 90 cycles.

Therefore it is a good idea to cache the result of this expensive computation. An additional benefit is that the costly division is only done when it is actually needed by the code. Currently this is not the case since both expressions are always evaluated, but with future modifications it may become useful.

Updated version of https://github.com/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition/pull/447.