### PR TITLE
Javax.annotation dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
 
   <dependencies>
     <dependency>
+       <groupId>javax.annotation</groupId>
+       <artifactId>javax.annotation-api</artifactId>
+       <version>1.3.2</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>


### PR DESCRIPTION
## Description

This PR adds this Javax dependency to the pom.xml file:
```xml
<dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>
    </dependency>
```
The aim of this change is to further improve the new employee experience when setting up the development environment for this project. Adding the dependency to the pom.xml file adds the dependency to Maven, thus adding the dependency to the project resolving the relevant missing import warnings a newly hired developer might run into. This import can be observed in multiple locations in the code, such as:

https://github.com/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition/blob/4922c077c07a3744ae67ee8a932786f15bf57411/src/main/java/com/seriouscompany/business/java/fizzbuzz/packagenamingpackage/impl/math/arithmetics/NumberIsMultipleOfAnotherNumberVerifier.java#L4

Which will otherwise result in errors such as:

<details>
 <summary>Logs</summary>

```console
Sep 22, 2020 10:09:29 PM org.springframework.context.support.ClassPathXmlApplicationContext prepareRefresh
INFO: Refreshing org.springframework.context.support.ClassPathXmlApplicationContext@7960847b: startup date [Tue Sep 22 22:09:29 EEST 2020]; root of context hierarchy
Sep 22, 2020 10:09:29 PM org.springframework.beans.factory.xml.XmlBeanDefinitionReader loadBeanDefinitions
INFO: Loading XML bean definitions from class path resource [spring.xml]
Sep 22, 2020 10:09:30 PM org.springframework.beans.factory.support.DefaultListableBeanFactory preInstantiateSingletons
INFO: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@11a9e7c8: defining beans [applicationContextHolder,buzzStrategyFactory,buzzStringPrinterFactory,buzzStringReturnerFactory,enterpriseGradeFizzBuzzSolutionStrategyFactory,fizzBuzzOutputGenerationContextVisitorFactory,fizzStrategyFactory,fizzStringPrinterFactory,fizzStringReturnerFactory,integerIntegerPrinterFactory,integerIntegerStringReturnerFactory,loopComponentFactory,newLineStringPrinterFactory,newLineStringReturnerFactory,noFizzNoBuzzStrategyFactory,systemOutFizzBuzzOutputStrategyFactory,loopCondition,loopInitializer,loopStep,integerDivider,numberIsMultipleOfAnotherNumberVerifier,buzzPrinter,buzzStringPrinter,fizzPrinter,fizzStringPrinter,integerIntegerPrinter,integerPrinter,newLinePrinter,newLineStringPrinter,standardFizzBuzz,buzzStrategy,firstIsLargerThanSecondDoubleComparator,firstIsSmallerThanSecondDoubleComparator,integerForEqualityComparator,threeWayIntegerComparator,buzzStrategyConstants,fizzStrategyConstants,noFizzNoBuzzStrategyConstants,doubleToIntConverter,intToDoubleConverter,enterpriseGradeFizzBuzzSolutionStrategy,fizzStrategy,noFizzNoBuzzStrategy,singleStepOutputGenerationStrategy,singleStepPayload,systemOutFizzBuzzOutputStrategy,buzzStringReturner,fizzStringReturner,integerIntegerStringReturner,newLineStringReturner,fizzBuzzOutputGenerationContextVisitor,org.springframework.context.annotation.internalConfigurationAnnotationProcessor,org.springframework.context.annotation.internalAutowiredAnnotationProcessor,org.springframework.context.annotation.internalRequiredAnnotationProcessor,org.springframework.context.annotation.ConfigurationClassPostProcessor.importAwareProcessor]; root of factory hierarchy
Sep 22, 2020 10:09:30 PM org.springframework.context.support.ClassPathXmlApplicationContext prepareRefresh
INFO: Refreshing org.springframework.context.support.ClassPathXmlApplicationContext@5aa9e4eb: startup date [Tue Sep 22 22:09:30 EEST 2020]; root of context hierarchy
Sep 22, 2020 10:09:30 PM org.springframework.beans.factory.xml.XmlBeanDefinitionReader loadBeanDefinitions
INFO: Loading XML bean definitions from class path resource [spring.xml]
Sep 22, 2020 10:09:30 PM org.springframework.beans.factory.support.DefaultListableBeanFactory preInstantiateSingletons
INFO: Pre-instantiating singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@510f3d34: defining beans [applicationContextHolder,buzzStrategyFactory,buzzStringPrinterFactory,buzzStringReturnerFactory,enterpriseGradeFizzBuzzSolutionStrategyFactory,fizzBuzzOutputGenerationContextVisitorFactory,fizzStrategyFactory,fizzStringPrinterFactory,fizzStringReturnerFactory,integerIntegerPrinterFactory,integerIntegerStringReturnerFactory,loopComponentFactory,newLineStringPrinterFactory,newLineStringReturnerFactory,noFizzNoBuzzStrategyFactory,systemOutFizzBuzzOutputStrategyFactory,loopCondition,loopInitializer,loopStep,integerDivider,numberIsMultipleOfAnotherNumberVerifier,buzzPrinter,buzzStringPrinter,fizzPrinter,fizzStringPrinter,integerIntegerPrinter,integerPrinter,newLinePrinter,newLineStringPrinter,standardFizzBuzz,buzzStrategy,firstIsLargerThanSecondDoubleComparator,firstIsSmallerThanSecondDoubleComparator,integerForEqualityComparator,threeWayIntegerComparator,buzzStrategyConstants,fizzStrategyConstants,noFizzNoBuzzStrategyConstants,doubleToIntConverter,intToDoubleConverter,enterpriseGradeFizzBuzzSolutionStrategy,fizzStrategy,noFizzNoBuzzStrategy,singleStepOutputGenerationStrategy,singleStepPayload,systemOutFizzBuzzOutputStrategy,buzzStringReturner,fizzStringReturner,integerIntegerStringReturner,newLineStringReturner,fizzBuzzOutputGenerationContextVisitor,org.springframework.context.annotation.internalConfigurationAnnotationProcessor,org.springframework.context.annotation.internalAutowiredAnnotationProcessor,org.springframework.context.annotation.internalRequiredAnnotationProcessor,org.springframework.context.annotation.ConfigurationClassPostProcessor.importAwareProcessor]; root of factory hierarchy
Sep 22, 2020 10:09:30 PM org.springframework.context.support.ClassPathXmlApplicationContext doClose
INFO: Closing org.springframework.context.support.ClassPathXmlApplicationContext@5aa9e4eb: startup date [Tue Sep 22 22:09:30 EEST 2020]; root of context hierarchy
Sep 22, 2020 10:09:30 PM org.springframework.beans.factory.support.DefaultListableBeanFactory destroySingletons
INFO: Destroying singletons in org.springframework.beans.factory.support.DefaultListableBeanFactory@510f3d34: defining beans [applicationContextHolder,buzzStrategyFactory,buzzStringPrinterFactory,buzzStringReturnerFactory,enterpriseGradeFizzBuzzSolutionStrategyFactory,fizzBuzzOutputGenerationContextVisitorFactory,fizzStrategyFactory,fizzStringPrinterFactory,fizzStringReturnerFactory,integerIntegerPrinterFactory,integerIntegerStringReturnerFactory,loopComponentFactory,newLineStringPrinterFactory,newLineStringReturnerFactory,noFizzNoBuzzStrategyFactory,systemOutFizzBuzzOutputStrategyFactory,loopCondition,loopInitializer,loopStep,integerDivider,numberIsMultipleOfAnotherNumberVerifier,buzzPrinter,buzzStringPrinter,fizzPrinter,fizzStringPrinter,integerIntegerPrinter,integerPrinter,newLinePrinter,newLineStringPrinter,standardFizzBuzz,buzzStrategy,firstIsLargerThanSecondDoubleComparator,firstIsSmallerThanSecondDoubleComparator,integerForEqualityComparator,threeWayIntegerComparator,buzzStrategyConstants,fizzStrategyConstants,noFizzNoBuzzStrategyConstants,doubleToIntConverter,intToDoubleConverter,enterpriseGradeFizzBuzzSolutionStrategy,fizzStrategy,noFizzNoBuzzStrategy,singleStepOutputGenerationStrategy,singleStepPayload,systemOutFizzBuzzOutputStrategy,buzzStringReturner,fizzStringReturner,integerIntegerStringReturner,newLineStringReturner,fizzBuzzOutputGenerationContextVisitor,org.springframework.context.annotation.internalConfigurationAnnotationProcessor,org.springframework.context.annotation.internalAutowiredAnnotationProcessor,org.springframework.context.annotation.internalRequiredAnnotationProcessor,org.springframework.context.annotation.ConfigurationClassPostProcessor.importAwareProcessor]; root of factory hierarchy
Exception in thread "main" java.lang.NullPointerException
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.math.arithmetics.NumberIsMultipleOfAnotherNumberVerifier.numberIsMultipleOfAnotherNumber(NumberIsMultipleOfAnotherNumberVerifier.java:41)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.FizzStrategy.isEvenlyDivisible(FizzStrategy.java:20)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.visitors.FizzBuzzOutputGenerationContextVisitor.visit(FizzBuzzOutputGenerationContextVisitor.java:24)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.SingleStepOutputGenerationStrategy.performGenerationForCurrentStep(SingleStepOutputGenerationStrategy.java:71)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.SingleStepPayload.runLoopPayload(SingleStepPayload.java:36)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.loop.LoopRunner.runLoop(LoopRunner.java:34)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.strategies.EnterpriseGradeFizzBuzzSolutionStrategy.runSolution(EnterpriseGradeFizzBuzzSolutionStrategy.java:36)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.StandardFizzBuzz.fizzBuzz(StandardFizzBuzz.java:33)
	at com.seriouscompany.business.java.fizzbuzz.packagenamingpackage.impl.Main.main(Main.java:23)

Process finished with exit code 1
```
</details>

## Related Issues

Fixes #434

## Tests

Not necessary, this is a development environment PR.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition/blob/uinverse/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the Contributors Non-Competition Clause.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.