### PR TITLE
fix(sec): upgrade org.springframework:spring-core to 5.3.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>3.2.13.RELEASE</version>
+        <version>5.3.14</version>
     </dependency>
     <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-core 3.2.13.RELEASE
- [CVE-2021-22060](https://www.oscs1024.com/hd/CVE-2021-22060)


### What did I do？
Upgrade org.springframework:spring-core from 3.2.13.RELEASE to 5.3.14 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS