### PR TITLE
fix(sec): upgrade org.springframework:spring-beans to 5.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>3.2.13.RELEASE</version>
+        <version>5.3.20</version>
     </dependency>
     <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-beans 3.2.13.RELEASE
- [CVE-2022-22965](https://www.oscs1024.com/hd/CVE-2022-22965)


### What did I do？
Upgrade org.springframework:spring-beans from 3.2.13.RELEASE to 5.3.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS